### PR TITLE
Fixed Pause menu bug

### DIFF
--- a/Assets/Scripts/Managers/LoadingScreenManager.cs
+++ b/Assets/Scripts/Managers/LoadingScreenManager.cs
@@ -121,6 +121,8 @@ public class LoadingScreenManager : MonoBehaviour
 
         onComplete?.Invoke(); // run after scene loads
 
+        // idk maybe move this somewhere else I just couldn't find where
+        GameObject.Find("GameManager").GetComponent<UIManager>().ClearMenuMap(); // resets spawned menus tracked by UI manager
         // Fade out
         yield return FadeCanvas(1f, 0f, 0.5f);
 

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -136,6 +136,11 @@ public class UIManager : MonoBehaviour
         }
     }
 
+    public void ClearMenuMap()
+    {
+        menuMap.Clear();
+    }
+
     public MenuType GetCurrentMenuType()
     {
         if (currentMenu != null)

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -14,6 +14,7 @@ public class PauseMenu : MonoBehaviour, IGameMenu
 
     private void Awake()
     {
+        DontDestroyOnLoad(gameObject);
         resumeButton.onClick.AddListener(OnResume);
         saveButton.onClick.AddListener(OnSave);
         mainMenuButton.onClick.AddListener(OnMainMenu);


### PR DESCRIPTION
Just stopped reset the menuMap list since it was tracking spawned menus and it would think the pause menu was still spawned in the new level.

^ i didnt write this I assume Thomas did